### PR TITLE
Implement VM stop endpoint and tests for provider and requestor

### DIFF
--- a/provider-server/provider/api/routes.py
+++ b/provider-server/provider/api/routes.py
@@ -122,18 +122,19 @@ async def get_vm_access(
         raise HTTPException(status_code=500, detail="An unexpected error occurred")
 
 
-@router.post("/vms/{requestor_name}/stop")
+@router.post("/vms/{requestor_name}/stop", response_model=VMInfo)
 @inject
 async def stop_vm(
     requestor_name: str,
     vm_service: VMService = Depends(Provide[Container.vm_service]),
-) -> None:
+) -> VMInfo:
     """Stop a VM."""
     try:
         logger.process(f"🛑 Stopping VM '{requestor_name}'")
-        await vm_service.stop_vm(requestor_name)
-        vm_status_change(requestor_name, "STOPPED", "VM stopped")
+        vm_info = await vm_service.stop_vm(requestor_name)
+        vm_status_change(requestor_name, vm_info.status.value, "VM stopped")
         logger.success(f"✨ Successfully stopped VM '{requestor_name}'")
+        return vm_info
     except VMNotFoundError as e:
         logger.error(f"VM not found: {e}")
         raise HTTPException(status_code=404, detail=str(e))

--- a/provider-server/provider/vm/service.py
+++ b/provider-server/provider/vm/service.py
@@ -69,12 +69,12 @@ class VMService:
         finally:
             await self.name_mapper.remove_mapping(vm_id)
 
-    async def stop_vm(self, vm_id: str) -> None:
-        """Stop a VM."""
+    async def stop_vm(self, vm_id: str) -> VMInfo:
+        """Stop a VM and return its updated status."""
         multipass_name = await self.name_mapper.get_multipass_name(vm_id)
         if not multipass_name:
             raise VMNotFoundError(f"VM {vm_id} not found")
-        await self.provider.stop_vm(multipass_name)
+        return await self.provider.stop_vm(multipass_name)
  
     async def list_vms(self) -> List[VMInfo]:
         """List all VMs."""

--- a/provider-server/tests/api/test_routes.py
+++ b/provider-server/tests/api/test_routes.py
@@ -4,7 +4,7 @@ from fastapi.testclient import TestClient
 from provider.main import app
 from provider.container import Container
 from provider.vm.service import VMService
-from provider.vm.models import VMInfo, VMStatus, VMResources
+from provider.vm.models import VMInfo, VMStatus, VMResources, VMNotFoundError
 
 @pytest.fixture
 def client() -> TestClient:
@@ -70,7 +70,31 @@ def test_delete_vm_happy_path(client: TestClient, mock_vm_service: VMService):
 
     # Assert
     assert response.status_code == 200
-from provider.vm.models import VMNotFoundError
+
+
+def test_stop_vm_happy_path(client: TestClient, mock_vm_service: VMService):
+    # Arrange
+    vm_info = VMInfo(id="test-vm", name="test-vm", status=VMStatus.STOPPED, resources=VMResources(cpu=2, memory=2, storage=20))
+    mock_vm_service.stop_vm = AsyncMock(return_value=vm_info)
+
+    # Act
+    response = client.post("/api/v1/vms/test-vm/stop")
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json()["status"] == "stopped"
+
+
+def test_stop_vm_not_found(client: TestClient, mock_vm_service: VMService):
+    # Arrange
+    mock_vm_service.stop_vm = AsyncMock(side_effect=VMNotFoundError("VM not found"))
+
+    # Act
+    response = client.post("/api/v1/vms/test-vm/stop")
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "VM not found"
 
 def test_create_vm_invalid_data(client: TestClient):
     # Arrange

--- a/requestor-server/tests/services/test_vm_service_requestor.py
+++ b/requestor-server/tests/services/test_vm_service_requestor.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from requestor.services.vm_service import VMService
+from requestor.services.database_service import DatabaseService
+from requestor.services.ssh_service import SSHService
+from requestor.provider.client import ProviderClient
+from requestor.errors import VMError
+
+
+@pytest.mark.asyncio
+async def test_stop_vm_updates_status(tmp_path):
+    db_path = tmp_path / "test.db"
+    db_service = DatabaseService(db_path)
+    await db_service.init()
+    await db_service.save_vm(
+        name="test-vm",
+        provider_ip="127.0.0.1",
+        vm_id="vm-id-123",
+        config={"cpu": 1, "memory": 1, "storage": 10, "ssh_port": 2222},
+    )
+
+    provider_client = MagicMock(spec=ProviderClient)
+    provider_client.stop_vm = AsyncMock()
+    ssh_service = MagicMock(spec=SSHService)
+
+    vm_service = VMService(db_service, ssh_service, provider_client)
+    await vm_service.stop_vm("test-vm")
+
+    provider_client.stop_vm.assert_awaited_once_with("vm-id-123")
+    vm = await db_service.get_vm("test-vm")
+    assert vm["status"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_stop_vm_not_found(tmp_path):
+    db_path = tmp_path / "test.db"
+    db_service = DatabaseService(db_path)
+    await db_service.init()
+
+    provider_client = MagicMock(spec=ProviderClient)
+    provider_client.stop_vm = AsyncMock()
+    ssh_service = MagicMock(spec=SSHService)
+
+    vm_service = VMService(db_service, ssh_service, provider_client)
+
+    with pytest.raises(VMError):
+        await vm_service.stop_vm("missing-vm")
+    provider_client.stop_vm.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Return VM info from provider VMService.stop_vm and expose it via new API response
- Add provider and requestor tests ensuring VM stop uses name mapping and updates status

## Testing
- `GOLEM_PROVIDER_MULTIPASS_BINARY_PATH=/usr/bin/true PYTHONPATH=provider-server:requestor-server pytest provider-server/tests requestor-server/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68bebcaf1c2883258acb1c217270e236