### PR TITLE
refactor: modularize requestor setup and add tests

### DIFF
--- a/requestor-server/tests/test_api.py
+++ b/requestor-server/tests/test_api.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from fastapi.testclient import TestClient
+import requestor.api.main as api_main
+
+
+def test_read_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(api_main.config, "db_path", tmp_path / "vms.db")
+    with TestClient(api_main.app) as client:
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert resp.json() == {"message": "Golem Requestor API"}
+
+
+def test_list_vms_no_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(api_main.config, "db_path", tmp_path / "vms.db")
+    with TestClient(api_main.app) as client:
+        api_main.db_service = None
+        resp = client.get("/vms")
+        assert resp.status_code == 500
+
+
+def test_list_vms_returns_vms(tmp_path, monkeypatch):
+    monkeypatch.setattr(api_main.config, "db_path", tmp_path / "vms.db")
+    with TestClient(api_main.app) as client:
+        class Dummy:
+            async def list_vms(self):
+                return [{"name": "n"}]
+        api_main.db_service = Dummy()
+        resp = client.get("/vms")
+        assert resp.status_code == 200
+        assert resp.json() == [{"name": "n"}]

--- a/requestor-server/tests/test_config.py
+++ b/requestor-server/tests/test_config.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import pytest
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from requestor.config import RequestorConfig
+
+
+def test_default_paths(monkeypatch, tmp_path):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    cfg = RequestorConfig()
+    expected_base = tmp_path / ".golem"
+    assert cfg.base_dir == expected_base
+    assert cfg.ssh_key_dir == expected_base / "ssh"
+    assert cfg.db_path == expected_base / "vms.db"
+
+
+def test_dev_mode_env(monkeypatch):
+    monkeypatch.setenv("golem_dev_mode", "true")
+    cfg = RequestorConfig()
+    assert cfg.environment == "development"
+    assert cfg.DEV_MODE is True
+
+
+def test_discovery_url_dev_mode():
+    cfg = RequestorConfig(environment="development")
+    assert cfg.discovery_url.startswith("DEVMODE-")
+
+
+def test_get_provider_url():
+    cfg = RequestorConfig()
+    assert cfg.get_provider_url("127.0.0.1") == "http://127.0.0.1:7466"
+
+
+def test_custom_base_dir(tmp_path):
+    cfg = RequestorConfig(base_dir=tmp_path)
+    assert cfg.ssh_key_dir == tmp_path / "ssh"
+    assert cfg.db_path == tmp_path / "vms.db"
+
+
+def test_force_localhost_default_false():
+    cfg = RequestorConfig()
+    assert cfg.force_localhost is False
+
+
+def test_force_localhost_true():
+    cfg = RequestorConfig(force_localhost=True)
+    assert cfg.force_localhost is True
+
+
+def test_discovery_url_production():
+    cfg = RequestorConfig(environment="production")
+    assert not cfg.discovery_url.startswith("DEVMODE-")
+
+
+def test_db_path_not_overwritten(tmp_path):
+    custom = tmp_path / "my.db"
+    cfg = RequestorConfig(db_path=custom)
+    assert cfg.db_path == custom
+
+
+def test_get_provider_url_dev_mode():
+    cfg = RequestorConfig(environment="development")
+    url = cfg.get_provider_url("1.2.3.4")
+    assert url == "http://1.2.3.4:7466"

--- a/requestor-server/tests/test_database_service.py
+++ b/requestor-server/tests/test_database_service.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from requestor.services.database_service import DatabaseService
+from requestor.errors import DatabaseError
+
+
+@pytest.mark.asyncio
+async def test_database_service_save_and_get(tmp_path):
+    svc = DatabaseService(tmp_path / "d.db")
+    await svc.init()
+    await svc.save_vm("a", "ip", "id", {"cpu": 1})
+    vm = await svc.get_vm("a")
+    assert vm["vm_id"] == "id"
+
+
+@pytest.mark.asyncio
+async def test_database_service_error_wrapped(tmp_path, monkeypatch):
+    svc = DatabaseService(tmp_path / "d.db")
+    await svc.init()
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("x")
+
+    monkeypatch.setattr(svc.db, "save_vm", boom)
+    with pytest.raises(DatabaseError):
+        await svc.save_vm("a", "ip", "id", {})
+
+
+@pytest.mark.asyncio
+async def test_database_service_list_vms(tmp_path):
+    svc = DatabaseService(tmp_path / "d.db")
+    await svc.init()
+    for i in range(2):
+        await svc.save_vm(f"n{i}", "ip", f"id{i}", {"cpu": 1})
+    vms = await svc.list_vms()
+    assert len(vms) == 2
+
+
+@pytest.mark.asyncio
+async def test_database_service_delete_vm(tmp_path):
+    svc = DatabaseService(tmp_path / "d.db")
+    await svc.init()
+    await svc.save_vm("n", "ip", "id", {})
+    await svc.delete_vm("n")
+    assert await svc.get_vm("n") is None
+
+
+@pytest.mark.asyncio
+async def test_database_service_update_status(tmp_path):
+    svc = DatabaseService(tmp_path / "d.db")
+    await svc.init()
+    await svc.save_vm("n", "ip", "id", {}, status="running")
+    await svc.update_vm_status("n", "stopped")
+    vm = await svc.get_vm("n")
+    assert vm["status"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_get_vm_nonexistent(tmp_path):
+    svc = DatabaseService(tmp_path / "d.db")
+    await svc.init()
+    assert await svc.get_vm("missing") is None
+
+
+@pytest.mark.asyncio
+async def test_database_service_execute_and_fetch(tmp_path):
+    svc = DatabaseService(tmp_path / "d.db")
+    await svc.init()
+    await svc.execute(
+        "INSERT INTO vms (name, provider_ip, vm_id, config) VALUES (?, ?, ?, ?)",
+        ("n", "ip", "id", "{}"),
+    )
+    row = await svc.fetchone("SELECT vm_id FROM vms WHERE name=?", ("n",))
+    assert row["vm_id"] == "id"

--- a/requestor-server/tests/test_db_sqlite.py
+++ b/requestor-server/tests/test_db_sqlite.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from requestor.db.sqlite import Database
+
+
+@pytest.mark.asyncio
+async def test_init_creates_table(tmp_path):
+    db = Database(tmp_path / "t.db")
+    await db.init()
+    assert (tmp_path / "t.db").exists()
+    tables = await db.fetchall(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='vms'"
+    )
+    assert tables
+
+
+@pytest.mark.asyncio
+async def test_save_and_get_vm(tmp_path):
+    db = Database(tmp_path / "t.db")
+    await db.init()
+    await db.save_vm("n", "ip", "id", {"cpu": 1}, "running")
+    vm = await db.get_vm("n")
+    assert vm["provider_ip"] == "ip"
+
+
+@pytest.mark.asyncio
+async def test_update_vm_status(tmp_path):
+    db = Database(tmp_path / "t.db")
+    await db.init()
+    await db.save_vm("n", "ip", "id", {"cpu": 1}, "running")
+    await db.update_vm_status("n", "stopped")
+    vm = await db.get_vm("n")
+    assert vm["status"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_delete_vm(tmp_path):
+    db = Database(tmp_path / "t.db")
+    await db.init()
+    await db.save_vm("n", "ip", "id", {"cpu": 1}, "running")
+    await db.delete_vm("n")
+    vm = await db.get_vm("n")
+    assert vm is None
+
+
+@pytest.mark.asyncio
+async def test_list_vms(tmp_path):
+    db = Database(tmp_path / "t.db")
+    await db.init()
+    for i in range(3):
+        await db.save_vm(f"n{i}", "ip", f"id{i}", {"cpu": 1}, "running")
+    vms = await db.list_vms()
+    assert len(vms) == 3
+
+
+@pytest.mark.asyncio
+async def test_execute_and_fetchone(tmp_path):
+    db = Database(tmp_path / "t.db")
+    await db.init()
+    await db.execute(
+        "INSERT INTO vms (name, provider_ip, vm_id, config) VALUES (?, ?, ?, ?)",
+        ("n", "ip", "id", "{}"),
+    )
+    row = await db.fetchone("SELECT vm_id FROM vms WHERE name=?", ("n",))
+    assert row["vm_id"] == "id"
+
+
+@pytest.mark.asyncio
+async def test_fetchall_empty(tmp_path):
+    db = Database(tmp_path / "t.db")
+    await db.init()
+    rows = await db.fetchall("SELECT * FROM vms")
+    assert rows == []

--- a/requestor-server/tests/test_errors.py
+++ b/requestor-server/tests/test_errors.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from requestor.errors import (
+    VMError,
+    ProviderError,
+    DiscoveryError,
+    SSHError,
+    ConfigError,
+    DatabaseError,
+    RequestorError,
+)
+
+
+def test_vm_error_vm_id():
+    err = VMError("oops", vm_id="123")
+    assert err.vm_id == "123"
+    assert str(err) == "oops"
+
+
+def test_provider_error_is_requestor_error():
+    err = ProviderError("p")
+    assert isinstance(err, RequestorError)
+    assert str(err) == "p"
+
+
+def test_discovery_error_is_requestor_error():
+    err = DiscoveryError("d")
+    assert isinstance(err, RequestorError)
+
+
+def test_ssh_error_is_requestor_error():
+    err = SSHError("s")
+    assert isinstance(err, RequestorError)
+
+
+def test_config_error_is_requestor_error():
+    err = ConfigError("c")
+    assert isinstance(err, RequestorError)
+
+
+def test_database_error_is_requestor_error():
+    err = DatabaseError("db")
+    assert isinstance(err, RequestorError)
+
+
+def test_vm_error_no_id():
+    err = VMError("oops")
+    assert err.vm_id is None

--- a/requestor-server/tests/test_provider_service.py
+++ b/requestor-server/tests/test_provider_service.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+import sys
+import types
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def stub_golem_base_sdk(monkeypatch):
+    class DummyClient:
+        @classmethod
+        async def create(cls, *args, **kwargs):
+            return cls()
+        async def disconnect(self):
+            pass
+        def http_client(self):
+            class HC:
+                class eth:
+                    async def get_block(self, arg):
+                        return SimpleNamespace(number=0)
+            return HC()
+    types_mod = types.ModuleType("golem_base_sdk.types")
+    types_mod.EntityKey = object
+    class GB:
+        @staticmethod
+        def from_hex_string(s):
+            return s
+    types_mod.GenericBytes = GB
+    sdk_mod = types.ModuleType("golem_base_sdk")
+    sdk_mod.GolemBaseClient = DummyClient
+    sdk_mod.types = types_mod
+    monkeypatch.setitem(sys.modules, "golem_base_sdk", sdk_mod)
+    monkeypatch.setitem(sys.modules, "golem_base_sdk.types", types_mod)
+
+    yield
+
+    sys.modules.pop("golem_base_sdk", None)
+    sys.modules.pop("golem_base_sdk.types", None)
+
+from requestor.services.provider_service import ProviderService
+from requestor.errors import ProviderError
+import click
+
+
+def test_provider_headers():
+    svc = ProviderService()
+    assert "Provider ID" in svc.provider_headers
+
+
+@pytest.mark.asyncio
+async def test_format_provider_row(monkeypatch):
+    provider = {
+        "provider_id": "pid",
+        "provider_name": "name",
+        "ip_address": "1.2.3.4",
+        "country": "PL",
+        "resources": {"cpu": 2, "memory": 4, "storage": 10},
+        "created_at_block": 0,
+    }
+    monkeypatch.setattr(click, "style", lambda x, **k: x)
+    svc = ProviderService()
+    row = await svc.format_provider_row(provider, colorize=True)
+    assert row[0] == "pid"
+    assert row[-1] == "N/A"
+
+
+@pytest.mark.asyncio
+async def test_check_resource_availability_false(monkeypatch):
+    svc = ProviderService()
+    async def fake_get(pid):
+        return {"cpu": 1, "memory": 1, "storage": 1}
+    monkeypatch.setattr(svc, "get_provider_resources", fake_get)
+    ok = await svc.check_resource_availability("p", 2, 2, 2)
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_verify_provider_missing(monkeypatch):
+    svc = ProviderService()
+    async def fake_find(*a, **k):
+        return [{"provider_id": "a"}]
+    monkeypatch.setattr(svc, "find_providers", fake_find)
+    with pytest.raises(ProviderError):
+        await svc.verify_provider("b")

--- a/requestor-server/tests/test_run.py
+++ b/requestor-server/tests/test_run.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from requestor.run import get_ssh_key_dir, secure_directory, check_requirements
+
+
+def test_get_ssh_key_dir_env(monkeypatch, tmp_path):
+    custom_dir = tmp_path / "ssh"
+    monkeypatch.setenv("GOLEM_REQUESTOR_SSH_KEY_DIR", str(custom_dir))
+    assert get_ssh_key_dir() == custom_dir
+
+
+def test_secure_directory_creates_and_sets_permissions(tmp_path):
+    target = tmp_path / "ssh"
+    assert secure_directory(target)
+    assert target.exists()
+    assert (target.stat().st_mode & 0o777) == 0o700
+
+
+def test_check_requirements_uses_secure_directory(monkeypatch, tmp_path):
+    target = tmp_path / "ssh"
+    monkeypatch.setenv("GOLEM_REQUESTOR_SSH_KEY_DIR", str(target))
+    assert check_requirements()
+    assert target.exists()
+    assert (target.stat().st_mode & 0o777) == 0o700
+
+
+def test_get_ssh_key_dir_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("GOLEM_REQUESTOR_SSH_KEY_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    expected = tmp_path / ".golem" / "requestor" / "ssh"
+    assert get_ssh_key_dir() == expected
+
+
+def test_secure_directory_failure(monkeypatch, tmp_path):
+    target = tmp_path / "ssh"
+    orig = Path.mkdir
+    def bad_mkdir(self, parents=False, exist_ok=False):
+        if self == target:
+            raise OSError("fail")
+        return orig(self, parents=parents, exist_ok=exist_ok)
+    monkeypatch.setattr(Path, "mkdir", bad_mkdir)
+    assert secure_directory(target) is False
+
+
+def test_check_requirements_failure(monkeypatch):
+    monkeypatch.setattr("requestor.run.secure_directory", lambda p: False)
+    assert check_requirements() is False

--- a/requestor-server/tests/test_ssh_manager.py
+++ b/requestor-server/tests/test_ssh_manager.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from requestor.ssh.manager import SSHKeyManager
+
+
+@pytest.mark.asyncio
+async def test_generate_key_pair(tmp_path):
+    mgr = SSHKeyManager(tmp_path)
+    pair = await mgr.get_key_pair()
+    assert pair.private_key.exists()
+    assert pair.public_key.exists()
+
+
+def test_get_key_pair_sync(tmp_path):
+    mgr = SSHKeyManager(tmp_path)
+    pair = mgr.get_key_pair_sync()
+    assert pair.private_key.exists()
+    assert pair.public_key.exists()
+
+
+@pytest.mark.asyncio
+async def test_get_public_key_content(tmp_path):
+    mgr = SSHKeyManager(tmp_path)
+    content = await mgr.get_public_key_content()
+    assert "ssh-rsa" in content

--- a/requestor-server/tests/test_ssh_service.py
+++ b/requestor-server/tests/test_ssh_service.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+import subprocess
+
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from requestor.services.ssh_service import SSHService
+from requestor.errors import SSHError
+
+
+def test_format_ssh_command(tmp_path):
+    svc = SSHService(tmp_path)
+    cmd = svc.format_ssh_command("host", 22, tmp_path / "key")
+    assert "ssh -i" in cmd and "host" in cmd
+
+
+def test_parse_stats():
+    svc = SSHService(Path("/tmp"))
+    sample = (
+        "%Cpu(s): 70.0 us, 30.0 id\n"
+        "MiB Mem : 2000 total, 1000 used, 1000 free\n"
+        "/dev/sda1 100G 50G 50G 50% /"
+    )
+    stats = svc._parse_stats(sample)
+    assert stats["cpu"]["usage"] == "70.0%"
+    assert stats["memory"]["total"].endswith("MiB")
+    assert stats["disk"]["used"] == "50G"
+
+
+def test_format_ssh_command_colorize(tmp_path, monkeypatch):
+    svc = SSHService(tmp_path)
+    import click
+    monkeypatch.setattr(click, "style", lambda x, **k: f"c:{x}")
+    cmd = svc.format_ssh_command("h", 22, tmp_path / "k", colorize=True)
+    assert cmd.startswith("c:")
+
+
+def test_get_key_pair_sync_error(tmp_path, monkeypatch):
+    svc = SSHService(tmp_path)
+    def boom():
+        raise RuntimeError("x")
+    monkeypatch.setattr(svc.ssh_manager, "get_key_pair_sync", boom)
+    with pytest.raises(SSHError):
+        svc.get_key_pair_sync()
+
+
+def test_connect_to_vm_calls_subprocess(tmp_path, monkeypatch):
+    svc = SSHService(tmp_path)
+    called = {}
+    def fake_run(cmd, check):
+        called["cmd"] = cmd
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    svc.connect_to_vm("host", 22, tmp_path / "k")
+    assert called["cmd"][0] == "ssh"
+
+
+def test_connect_to_vm_error(tmp_path, monkeypatch):
+    svc = SSHService(tmp_path)
+    def fake_run(cmd, check):
+        raise RuntimeError("bad")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(SSHError):
+        svc.connect_to_vm("host", 22, tmp_path / "k")
+
+
+def test_get_vm_stats_error(tmp_path, monkeypatch):
+    svc = SSHService(tmp_path)
+    def fake_run(*a, **k):
+        raise subprocess.CalledProcessError(1, "cmd", "err")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(SSHError):
+        svc.get_vm_stats("h", 22, tmp_path / "k")

--- a/requestor-server/tests/test_utils_logging.py
+++ b/requestor-server/tests/test_utils_logging.py
@@ -1,0 +1,41 @@
+import logging
+from pathlib import Path
+import io
+import logging
+
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from requestor.utils.logging import LogLevel, setup_logger
+
+
+def test_custom_methods_exist():
+    logger = setup_logger("test.custom")
+    for method in ("command", "process", "success", "detail"):
+        assert hasattr(logger, method)
+
+
+def test_setup_logger_debug_env(monkeypatch):
+    monkeypatch.setenv("DEBUG", "1")
+    logger = setup_logger("test.debug")
+    assert logger.level == logging.DEBUG
+
+
+def test_setup_logger_default_info(monkeypatch):
+    monkeypatch.delenv("DEBUG", raising=False)
+    logger = setup_logger("test.info")
+    assert logger.level == logging.INFO
+
+
+def test_logger_command_logs():
+    logger = setup_logger("test.log")
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(LogLevel.COMMAND.value)
+    logger.addHandler(handler)
+    logger.setLevel(LogLevel.COMMAND.value)
+    logger.command("hello")
+    handler.flush()
+    assert "hello" in stream.getvalue()

--- a/requestor-server/tests/test_utils_spinner.py
+++ b/requestor-server/tests/test_utils_spinner.py
@@ -1,0 +1,34 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from requestor.utils.spinner import Spinner, step
+
+
+def test_spinner_success_output(capsys):
+    with Spinner("work"):
+        pass
+    out = capsys.readouterr().out
+    assert "✓ work" in out
+
+
+def test_spinner_failure_output(capsys):
+    with pytest.raises(ValueError):
+        with Spinner("fail"):
+            raise ValueError("boom")
+    out = capsys.readouterr().out
+    assert "✗ fail" in out
+
+
+@pytest.mark.asyncio
+async def test_step_decorator_returns_value():
+    @step("doing")
+    async def sample():
+        await asyncio.sleep(0)
+        return 5
+
+    assert await sample() == 5

--- a/requestor-server/tests/test_vm_service.py
+++ b/requestor-server/tests/test_vm_service.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from requestor.services.vm_service import VMService
+
+
+class DummyDB:
+    def __init__(self, vm):
+        self.vm = vm
+
+    async def get_vm(self, name):
+        return self.vm
+
+
+def dummy_key_pair(tmp_path):
+    priv = tmp_path / "k"
+    priv.write_text("p")
+    pub = tmp_path / "k.pub"
+    pub.write_text("pub")
+    return SimpleNamespace(private_key=priv, public_key=pub)
+
+
+def test_vm_headers():
+    svc = VMService(SimpleNamespace(), SimpleNamespace())
+    headers = svc.vm_headers
+    assert "Name" in headers and "Status" in headers
+
+
+def test_format_vm_row(monkeypatch, tmp_path):
+    vm = {
+        "name": "n",
+        "status": "running",
+        "provider_ip": "ip",
+        "config": {"cpu": 1, "memory": 1, "storage": 1, "ssh_port": 22},
+        "created_at": "now",
+    }
+
+    db = DummyDB(vm)
+
+    class DummySSH:
+        def get_key_pair_sync(self):
+            return dummy_key_pair(tmp_path)
+
+        def format_ssh_command(self, **kwargs):
+            return "cmd"
+
+    svc = VMService(db, DummySSH(), SimpleNamespace())
+    row = svc.format_vm_row(vm)
+    assert row[0] == "n"
+    assert "cmd" in row[7]


### PR DESCRIPTION
## Summary
- modularize requestor setup utilities
- defer CLI import to runtime
- add unit tests for directory handling
- expand requestor tests for config, logging, spinner, database, SSH, and VM services
- broaden coverage with API, provider, SSH, and setup edge-case tests

## Testing
- `cd requestor-server && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bebcfb25a083259c003907e250b037