### PR TITLE
Automate version bumping in publish workflows

### DIFF
--- a/.github/workflows/publish-discovery.yml
+++ b/.github/workflows/publish-discovery.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Configure Poetry
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+      - name: Bump package version
+        run: |
+          python scripts/bump_versions.py discovery-server/pyproject.toml
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
       - name: Build and publish
         working-directory: ./discovery-server
         run: |

--- a/.github/workflows/publish-port-checker.yml
+++ b/.github/workflows/publish-port-checker.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Configure Poetry
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+      - name: Bump package version
+        run: |
+          python scripts/bump_versions.py port-checker-server/pyproject.toml
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
       - name: Build and publish
         working-directory: ./port-checker-server
         run: |

--- a/.github/workflows/publish-provider.yml
+++ b/.github/workflows/publish-provider.yml
@@ -21,6 +21,11 @@ jobs:
             - name: Configure Poetry
               run: |
                   poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+            - name: Bump package version
+              run: |
+                  python scripts/bump_versions.py provider-server/pyproject.toml
+              env:
+                  BUILD_NUMBER: ${{ github.run_number }}
             - name: Build and publish
               working-directory: ./provider-server
               run: |

--- a/.github/workflows/publish-requestor.yml
+++ b/.github/workflows/publish-requestor.yml
@@ -21,6 +21,11 @@ jobs:
             - name: Configure Poetry
               run: |
                   poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+            - name: Bump package version
+              run: |
+                  python scripts/bump_versions.py requestor-server/pyproject.toml
+              env:
+                  BUILD_NUMBER: ${{ github.run_number }}
             - name: Build and publish
               working-directory: ./requestor-server
               run: |

--- a/scripts/bump_versions.py
+++ b/scripts/bump_versions.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Utility to bump patch versions in pyproject.toml files.
+
+If the BUILD_NUMBER environment variable is provided, the patch version will
+be replaced with that number. Otherwise, the patch will be incremented by one.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+PATTERN = re.compile(r'version\s*=\s*"(\d+)\.(\d+)\.(\d+)"')
+
+
+def bump(text: str, build_number: int | None) -> tuple[str, bool]:
+    """Return text with bumped patch version and whether a change was made."""
+
+    def _replace(match: re.Match[str]) -> str:
+        major, minor, patch = map(int, match.groups())
+        if build_number is not None:
+            patch = build_number
+        else:
+            patch += 1
+        return f'version = "{major}.{minor}.{patch}"'
+
+    new_text, count = PATTERN.subn(_replace, text, count=1)
+    return new_text, bool(count)
+
+
+def process_file(path: Path, build_number: int | None) -> bool:
+    text = path.read_text()
+    new_text, changed = bump(text, build_number)
+    if changed:
+        path.write_text(new_text)
+    return changed
+
+
+def main() -> None:
+    if len(sys.argv) > 1:
+        files = [Path(p) for p in sys.argv[1:]]
+    else:
+        files = list(Path('.').glob('*/pyproject.toml'))
+
+    build_num_env = os.getenv('BUILD_NUMBER')
+    build_number = int(build_num_env) if build_num_env and build_num_env.isdigit() else None
+
+    for file in files:
+        if not file.exists():
+            print(f"Skipping missing {file}")
+            continue
+        if process_file(file, build_number):
+            print(f"Bumped {file}")
+        else:
+            print(f"No version found in {file}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add script to bump versions in pyproject based on BUILD_NUMBER
- run this script in each publish workflow so packages get unique versions

## Testing
- `pytest` (fails: No module named 'requestor')

------
https://chatgpt.com/codex/tasks/task_e_68bec2132860832593332bca0e47d922