### PR TITLE
Add Makefile for development tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: install test start
+
+install:
+	poetry -C discovery-server install
+	poetry -C provider-server install
+	poetry -C requestor-server install
+
+test:
+	poetry -C discovery-server run pytest || [ $$? -eq 5 ]
+	poetry -C provider-server run pytest || [ $$? -eq 5 ]
+	poetry -C requestor-server run pytest || [ $$? -eq 5 ]
+
+start:
+	@set -e; \
+	poetry -C discovery-server run golem-discovery & \
+	poetry -C provider-server run dev & \
+	poetry -C requestor-server run golem server api --reload & \
+	wait

--- a/README.md
+++ b/README.md
@@ -25,3 +25,34 @@ export GOLEM_REQUESTOR_ENVIRONMENT="development"
 ```
 
 If these variables are not set, the applications will default to `production` mode.
+
+## Development
+
+This repository provides a Makefile to streamline common tasks during development.
+
+### Install dependencies
+
+Install the discovery, provider, and requestor packages using Poetry:
+
+```bash
+make install
+```
+
+### Run tests
+
+Execute unit tests for all packages:
+
+```bash
+make test
+```
+
+### Start development servers
+
+Launch the discovery, provider, and requestor servers concurrently:
+
+```bash
+make start
+```
+
+This runs all three services in the foreground for local development.
+


### PR DESCRIPTION
## Summary
- add root Makefile with install, test and start targets for discovery, provider and requestor packages
- document Makefile usage in the project README

## Testing
- `make test` *(fails: Multipass binary not found during provider tests)*

------
https://chatgpt.com/codex/tasks/task_e_68becf62e78c8325b8a40fc7a1496804