### PR TITLE
fix: ensure version bump uses unique patch

### DIFF
--- a/scripts/bump_versions.py
+++ b/scripts/bump_versions.py
@@ -21,7 +21,7 @@ def bump(text: str, build_number: int | None) -> tuple[str, bool]:
     def _replace(match: re.Match[str]) -> str:
         major, minor, patch = map(int, match.groups())
         if build_number is not None:
-            patch = build_number
+            patch = build_number if build_number > patch else patch + 1
         else:
             patch += 1
         return f'version = "{major}.{minor}.{patch}"'


### PR DESCRIPTION
## Summary
- ensure bump_versions script always increments patch when build number is reused or lower

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'provider')*


------
https://chatgpt.com/codex/tasks/task_e_68bed22013a483259e2eb76166ab7163