### PR TITLE
Add config bootstrapping for requestor and provider CLIs

### DIFF
--- a/provider-server/provider/config.py
+++ b/provider-server/provider/config.py
@@ -11,6 +11,37 @@ from .utils.logging import setup_logger
 logger = setup_logger(__name__)
 
 
+def ensure_config() -> None:
+    """Ensure the provider configuration directory and defaults exist."""
+    base_dir = Path.home() / ".golem" / "provider"
+    env_file = base_dir / ".env"
+    subdirs = ["keys", "ssh", "vms", "proxy"]
+    created = False
+
+    for sub in subdirs:
+        path = base_dir / sub
+        if not path.exists():
+            path.mkdir(parents=True, exist_ok=True)
+            created = True
+
+    if not env_file.exists():
+        env_file.write_text("GOLEM_PROVIDER_ENVIRONMENT=production\n")
+        created = True
+
+    from .security.ethereum import EthereumIdentity
+
+    identity = EthereumIdentity(str(base_dir / "keys"))
+    if not identity.key_file.exists():
+        identity.get_or_create_identity()
+        created = True
+
+    if created:
+        print("Using default settings – run with --help to customize")
+
+
+ensure_config()
+
+
 class Settings(BaseSettings):
     """Provider configuration settings."""
 

--- a/requestor-server/requestor/cli/commands.py
+++ b/requestor-server/requestor/cli/commands.py
@@ -13,7 +13,7 @@ except ImportError:
     # Python < 3.8
     import importlib_metadata as metadata
 
-from ..config import config
+from ..config import config, ensure_config
 from ..provider.client import ProviderClient
 from ..errors import RequestorError
 from ..utils.logging import setup_logger
@@ -55,6 +55,7 @@ def print_version(ctx, param, value):
               expose_value=False, is_eager=True, help="Show the version and exit.")
 def cli():
     """VM on Golem management CLI"""
+    ensure_config()
     pass
 
 

--- a/requestor-server/tests/test_config.py
+++ b/requestor-server/tests/test_config.py
@@ -9,7 +9,7 @@ from requestor.config import RequestorConfig
 def test_default_paths(monkeypatch, tmp_path):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     cfg = RequestorConfig()
-    expected_base = tmp_path / ".golem"
+    expected_base = tmp_path / ".golem" / "requestor"
     assert cfg.base_dir == expected_base
     assert cfg.ssh_key_dir == expected_base / "ssh"
     assert cfg.db_path == expected_base / "vms.db"


### PR DESCRIPTION
## Summary
- migrate requestor config to Pydantic v2 with ensure_config invoked on import
- ensure provider config directories are initialized on import and clean up provider main imports
- update tests for new requestor config base path

## Testing
- `cd requestor-server && PYTHONPATH=. pytest`
- `cd provider-server && GOLEM_PROVIDER_MULTIPASS_BINARY_PATH=/bin/true PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bed082fdc08325a9c5b82a3c4c7491