### PR TITLE
feat: add connect and delete aliases for vm commands

### DIFF
--- a/requestor-server/requestor/cli/commands.py
+++ b/requestor-server/requestor/cli/commands.py
@@ -229,7 +229,7 @@ async def create_vm(name: str, provider_id: str, cpu: int, memory: int, storage:
 @click.argument('name')
 @async_command
 async def ssh_vm(name: str):
-    """SSH into a VM."""
+    """SSH into a VM (alias: connect)."""
     try:
         logger.command(f"🔌 Connecting to VM '{name}'")
         
@@ -272,6 +272,13 @@ async def ssh_vm(name: str):
             error_msg = "Unable to establish SSH connection (VM may be starting up)"
         logger.error(f"Failed to connect: {error_msg}")
         raise click.Abort()
+
+
+@vm.command(name="connect")
+@click.argument("name")
+def connect_vm(name: str):
+    """Connect to a VM via SSH (alias of ssh)."""
+    return ssh_vm.callback(name)
 
 
 @vm.command(name='info')
@@ -320,7 +327,7 @@ async def info_vm(name: str):
 @click.argument('name')
 @async_command
 async def destroy_vm(name: str):
-    """Destroy a VM."""
+    """Destroy a VM (alias: delete)."""
     try:
         logger.command(f"💥 Destroying VM '{name}'")
 
@@ -357,6 +364,13 @@ async def destroy_vm(name: str):
             error_msg = "VM not found on provider (it may have been manually removed)"
         logger.error(f"Failed to destroy VM: {error_msg}")
         raise click.Abort()
+
+
+@vm.command(name="delete")
+@click.argument("name")
+def delete_vm(name: str):
+    """Delete a VM (alias of destroy)."""
+    return destroy_vm.callback(name)
 
 
 @vm.command(name='purge')

--- a/requestor-server/tests/test_cli_vm_aliases.py
+++ b/requestor-server/tests/test_cli_vm_aliases.py
@@ -1,0 +1,73 @@
+import sys
+import types
+from pathlib import Path
+from importlib import reload
+
+import pytest
+from click.testing import CliRunner
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+class DummyDatabaseService:
+    def __init__(self, db_path):
+        self.db_path = db_path
+    async def init(self):
+        pass
+
+
+def load_commands(monkeypatch):
+    config_stub = types.SimpleNamespace(
+        db_path=Path('/tmp/db.sqlite'),
+        ssh_key_dir=Path('/tmp/ssh'),
+        get_provider_url=lambda ip: ip,
+        environment='development',
+    )
+    monkeypatch.setitem(sys.modules, 'requestor.config', types.SimpleNamespace(config=config_stub))
+    monkeypatch.setitem(sys.modules, 'requestor.services.database_service', types.SimpleNamespace(DatabaseService=DummyDatabaseService))
+    monkeypatch.setitem(sys.modules, 'requestor.services.ssh_service', types.SimpleNamespace(SSHService=object))
+    monkeypatch.setitem(sys.modules, 'requestor.services.vm_service', types.SimpleNamespace(VMService=object))
+    monkeypatch.setitem(sys.modules, 'requestor.services.provider_service', types.SimpleNamespace(ProviderService=object))
+    monkeypatch.setitem(sys.modules, 'requestor.provider.client', types.SimpleNamespace(ProviderClient=object))
+    monkeypatch.setitem(sys.modules, 'requestor.errors', types.SimpleNamespace(RequestorError=Exception))
+
+    import requestor.cli.commands as commands
+    reload(commands)
+    return commands
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_vm_connect_alias_calls_ssh_callback(runner, monkeypatch):
+    commands = load_commands(monkeypatch)
+    called = {}
+
+    def fake_callback(name: str):
+        called['name'] = name
+
+    monkeypatch.setattr(commands.ssh_vm, 'callback', fake_callback)
+    monkeypatch.setattr(commands, 'db_service', types.SimpleNamespace(init=lambda: None))
+
+    result = runner.invoke(commands.cli, ['vm', 'connect', 'myvm'])
+
+    assert result.exit_code == 0
+    assert called['name'] == 'myvm'
+
+
+def test_vm_delete_alias_calls_destroy_callback(runner, monkeypatch):
+    commands = load_commands(monkeypatch)
+    called = {}
+
+    def fake_callback(name: str):
+        called['name'] = name
+
+    monkeypatch.setattr(commands.destroy_vm, 'callback', fake_callback)
+    monkeypatch.setattr(commands, 'db_service', types.SimpleNamespace(init=lambda: None))
+
+    result = runner.invoke(commands.cli, ['vm', 'delete', 'oldvm'])
+
+    assert result.exit_code == 0
+    assert called['name'] == 'oldvm'


### PR DESCRIPTION
## Summary
- add `vm connect` command aliasing `ssh`
- add `vm delete` command aliasing `destroy`
- document new aliases in command help
- add tests covering the new CLI aliases

## Testing
- `pytest requestor-server/tests/test_cli_vm_aliases.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'provider'; ImportError: cannot import name 'Undefined' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_68bed28ead3883259ae71a6c879d8146