### PR TITLE
feat: add lock step to Makefile install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
-.PHONY: install test start
+.PHONY: install test start lock
 
-install:
+install: lock
 	poetry -C discovery-server install
 	poetry -C provider-server install
 	poetry -C requestor-server install
+
+lock:
+	poetry -C discovery-server lock
+	poetry -C provider-server lock
+	poetry -C requestor-server lock
 
 test:
 	poetry -C discovery-server run pytest || [ $$? -eq 5 ]


### PR DESCRIPTION
## Summary
- ensure `make install` generates up-to-date Poetry lock files

## Testing
- `make install`
- `make test` *(fails: ValidationError for Settings)*

------
https://chatgpt.com/codex/tasks/task_e_68bedb4737b883259fc77a90301d4046